### PR TITLE
removes encodeURIComponent

### DIFF
--- a/polymer-cookie.html
+++ b/polymer-cookie.html
@@ -117,7 +117,7 @@ Polymer({
 		}
 
 		return ( document.cookie = [
-			encodeURIComponent( this.name ), '=', encodeURIComponent( this.value ),
+			this.name '=', this.value,
 			"; expires=" + date.toGMTString(),
 			this.path   && "; path=" + this.path,
 			this.secure ? "; secure" : '',


### PR DESCRIPTION
I'm pretty confident encodeURIComponent is unnecessary. You're simply setting a string. Give the user control of the string.
